### PR TITLE
Using drawable instead of bitmap to set trail

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -42,7 +42,7 @@
         android:layout_marginStart="20dp"
         android:layout_marginBottom="20dp"
         app:button_trail_enabled="true"
-        app:button_trail_color="#FFF"
+        app:button_trail_drawable="@drawable/shape_button_squared"
         app:button_image_disabled="@drawable/ic_lock_open_black_24dp"
         app:button_image_enabled="@drawable/ic_lock_outline_black_24dp"
         app:button_background="@drawable/shape_button_squared"

--- a/swipe-button/src/main/java/com/ebanx/swipebtn/SwipeButton.java
+++ b/swipe-button/src/main/java/com/ebanx/swipebtn/SwipeButton.java
@@ -468,7 +468,7 @@ public class SwipeButton extends RelativeLayout {
             layer.setVisibility(View.VISIBLE);
             layer.setLayoutParams(new RelativeLayout.LayoutParams(
                     (int) (swipeButtonInner.getX() + swipeButtonInner.getWidth()),
-                    background.getHeight()));
+                    swipeButtonInner.getHeight()));
         }
     }
 

--- a/swipe-button/src/main/res/values/attrs.xml
+++ b/swipe-button/src/main/res/values/attrs.xml
@@ -12,7 +12,7 @@
         <attr name="button_image_width" format="dimension"/>
         <attr name="button_image_height" format="dimension"/>
         <attr name="button_trail_enabled" format="boolean"/>
-        <attr name="button_trail_color" format="color"/>
+        <attr name="button_trail_drawable" format="reference"/>
         <attr name="button_image_disabled" format="reference"/>
         <attr name="button_image_enabled" format="reference"/>
         <attr name="button_left_padding" format="dimension"/>


### PR DESCRIPTION
#13 
added an option to set a drawable for trail layer - for better results this should be of same shape as the swipe button's drawable.
instead of creating a bitmap each time, now changing the trail layer's layoutParams which is more efficient.