### PR TITLE
Remove application attributes

### DIFF
--- a/swipe-button/src/main/AndroidManifest.xml
+++ b/swipe-button/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
 
     package="com.ebanx.swipebtn">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
Don't specify application attributes in library manifest to avoid collision in the application.