### PR TITLE
Added opportunity to enable or disable inner text word wrap

### DIFF
--- a/swipe-button/src/main/java/com/ebanx/swipebtn/SwipeButton.java
+++ b/swipe-button/src/main/java/com/ebanx/swipebtn/SwipeButton.java
@@ -12,6 +12,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -212,6 +213,12 @@ public class SwipeButton extends RelativeLayout {
                 centerText.setTextSize(textSize);
             } else {
                 centerText.setTextSize(12);
+            }
+
+            boolean textWrap = typedArray.getBoolean(R.styleable.SwipeButton_inner_text_wrap, false);
+            if (!textWrap) {
+                centerText.setMaxLines(1);
+                centerText.setEllipsize(TextUtils.TruncateAt.END);
             }
 
             disabledDrawable = typedArray.getDrawable(R.styleable.SwipeButton_button_image_disabled);

--- a/swipe-button/src/main/res/values/attrs.xml
+++ b/swipe-button/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="inner_text_top_padding" format="dimension"/>
         <attr name="inner_text_bottom_padding" format="dimension"/>
         <attr name="inner_text_background" format="reference"/>
+        <attr name="inner_text_wrap" format="boolean"/>
         <attr name="button_image_width" format="dimension"/>
         <attr name="button_image_height" format="dimension"/>
         <attr name="button_trail_enabled" format="boolean"/>


### PR DESCRIPTION
I've added new attribute "inner_text_wrap" as boolean. If you'll set it's value to true (false is default value) then text in inner TextView will expand it's height. False value will cut your text with three dots at the end.