### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/gnag-build.sh
+++ b/gnag-build.sh
@@ -2,9 +2,8 @@
 set -ev
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-    ./gradlew gnagCheck --no-daemon
+    ./gradlew gnagCheck --daemon
 else
-    ./gradlew gnagReport -PauthToken="${GNAG_AUTH_TOKEN}" -PissueNumber="${TRAVIS_PULL_REQUEST}" --no-daemon
+    ./gradlew gnagReport -PauthToken="${GNAG_AUTH_TOKEN}" -PissueNumber="${TRAVIS_PULL_REQUEST}" --daemon
 fi
-
 


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
